### PR TITLE
Created fix for numpy error: index out of range (for Docker only)

### DIFF
--- a/Dockerfile-addendum
+++ b/Dockerfile-addendum
@@ -1,0 +1,15 @@
+# Udacity capstone project dockerfile
+FROM capstone
+
+# reinstall pillow ignoring the cached version so as to properly link with the libjpeg. This allows us to read the jpeg encoding of the incoming image
+RUN pip install --no-cache-dir -I pillow
+
+# install matplotlib to aid the debugging of images
+RUN pip install matplotlib
+
+# install python-tk, a run-time dependency for matplotlib
+RUN apt-get install -y python-tk
+
+VOLUME ["/capstone"]
+VOLUME ["/root/.ros/log/"]
+WORKDIR /capstone/ros

--- a/README.md
+++ b/README.md
@@ -24,10 +24,26 @@ Build the docker container
 ```bash
 docker build . -t capstone
 ```
+### Additional Steps to install packages for debugging images and properly translating to numpy arrays
+### (install into docker image capstone:v1.1)
+`docker build -f ./Dockerfile-addendum -t capstone:v1.1 . `
 
 Run the docker file
 ```bash
-docker run -p 127.0.0.1:4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it capstone
+docker run -p 127.0.0.1:4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ --rm -it capstone:v1.1
+```
+
+### To view the image-gui perform the following steps:
+`./run-gui.sh`
+
+Export the current container's ID
+`export containerId=$(docker ps -l -q)`
+
+Grant the current container access to the xhost, for display.
+
+```bash
+xhost +local:`docker inspect --format='{{ .Config.Hostname }}' $containerId`
+`docker start $containerId`
 ```
 
 ### Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ scipy==0.19.1
 keras==2.0.8
 tensorflow==1.3.0
 h5py==2.6.0
+
+matplotlib

--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -11,6 +11,7 @@ from sensor_msgs.msg import Image
 import sensor_msgs.point_cloud2 as pcl2
 from std_msgs.msg import Header
 from cv_bridge import CvBridge, CvBridgeError
+import matplotlib.pyplot as plt
 
 from styx_msgs.msg import TrafficLight, TrafficLightArray
 import numpy as np
@@ -175,7 +176,11 @@ class Bridge(object):
     def publish_camera(self, data):
         imgString = data["image"]
         image = PIL_Image.open(BytesIO(base64.b64decode(imgString)))
-        image_array = np.asarray(image)
+        image_array = np.array(image.getdata(), dtype=np.uint8)
+        image_array = image_array.reshape(image.height, image.width, 3)
+
+        plt.imshow(image_array)
+        plt.show()
 
         image_message = self.bridge.cv2_to_imgmsg(image_array, encoding="rgb8")
         self.publishers['image'].publish(image_message)

--- a/ros/src/waypoint_updater/launch/waypoint_updater.launch
+++ b/ros/src/waypoint_updater/launch/waypoint_updater.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="waypoint_updater" type="waypoint_updater.py" name="waypoint_updater" />
+    <node pkg="waypoint_updater" type="waypoint_updater.py" name="waypoint_updater" output="screen"/>
 </launch>

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -64,9 +64,9 @@ class WaypointUpdater(object):
                 # Calculate distance
                 dist = math.sqrt((car_x - wp_x)**2 + (car_y - wp_y)**2)
 
-                    if dist < min_dist:
-                        min_dist = dist
-                        index = i
+                if dist < min_dist:
+                    min_dist = dist
+                    index = i
 
             # Add 1 to the index just to make sure the first point is in front of the car
             # TODO: Find a better way to determine if the nearest point is in front of the car
@@ -74,21 +74,23 @@ class WaypointUpdater(object):
 
     def pose_cb(self, msg):
         # Update current position
-        self.curr_pose = msg.pose.pose.position
+        self.curr_pose = msg.pose.position
         
         # Find the next waypoint
         next_wp = self.next_waypoint()
 
         # Store next waypoints
-        waypoints = self.waypoints[next_wp: next_wp + LOOKAHEAD_WPS]
+        if next_wp:
+            waypoints = self.waypoints[next_wp: next_wp + LOOKAHEAD_WPS]
 
-        # Publish waypoints
-        message = Lane(waypoints=waypoints)
-        self.final_waypoints_pub.publish(message)
+            # Publish waypoints
+            message = Lane(waypoints=waypoints)
+            self.final_waypoints_pub.publish(message)
 
     def waypoints_cb(self, lane):
         # Published only once - doesn't change
         self.waypoints = lane.waypoints
+        print ("waypoints received")
 
     def traffic_cb(self, msg):
         # TODO: Callback for /traffic_waypoint message. Implement

--- a/run-gui.sh
+++ b/run-gui.sh
@@ -1,0 +1,11 @@
+docker run -it \
+    -p 127.0.0.1:4567:4567 -v $PWD:/capstone -v /tmp/log:/root/.ros/ \
+    --env="DISPLAY" \
+    --env="QT_X11_NO_MITSHM=1" \
+    --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+    capstone-1.1 
+
+
+# Above, we made the container's processes interactive, forwarded our DISPLAY environment variable, mounted a volume for the X11 unix socket. 
+# For more info, visit:  http://wiki.ros.org/docker/Tutorials/GUI
+


### PR DESCRIPTION
Running from Docker, the error 
" img_msg.height = cvim.shape[0] IndexError: tuple index out of range" occurred because the PIL_Image.open() in the function publish_camera() couldn't correctly parse the jpeg format. 

To fix this, I added a docker file called Dockerfile-addendum which reinstalls pillow (source of the PIL_Image) without considering the cached version. This has proven to work locally on my machine and the README has been updated with the corresponding steps.

You can also do this update manually by running (while in the docker container):
pip install --no-cache-dir -I pillow
